### PR TITLE
Buidler Hooks: Add token manager creation script

### DIFF
--- a/contracts/test/TestImport.sol
+++ b/contracts/test/TestImport.sol
@@ -1,0 +1,20 @@
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
+
+// You might think this file is a bit odd, but let me explain.
+// We only use some contracts in our tests, which means Truffle
+// will not compile it for us, because it is from an external
+// dependency.
+//
+// We are now left with three options:
+// - Copy/paste these contracts
+// - Run the tests with `truffle compile --all` on
+// - Or trick Truffle by claiming we use it in a Solidity test
+//
+// You know which one I went for.
+
+
+contract TestImports {
+    constructor() public {
+        // solium-disable-previous-line no-empty-blocks
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "publish:patch": "buidler publish patch"
   },
   "dependencies": {
-    "@aragon/abis": "^1.1.0"
+    "@aragon/abis": "^1.1.0",
+    "@aragon/apps-shared-minime": "^1.0.2",
+    "@aragon/minime": "^1.0.0"
   },
   "devDependencies": {
     "@aragon/buidler-aragon": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@aragon/abis/-/abis-1.1.0.tgz#e94e94c57d50fd736856751b6224905e6f0e9e86"
   integrity sha512-SbdF3JkU+57N19GEENtUvs/nsjOKdK+YlG35o3qdhK8AMZO+AWZU3wb5FyezR4hHHDZfijxhzYTXGIf0zNAdPQ==
 
+"@aragon/apps-shared-minime@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.2.tgz#1388602be2b296de51e6c3712c80d669c1d2191e"
+  integrity sha512-HqvnjU4sF2swvOK3616cvuSs2sofegWd7qqT5iF0YTf9v0w/cAWoj7ZZK3TMVdsQv07HNvQjqucTGa3/qMzblA==
+
 "@aragon/buidler-aragon@^0.2.2":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@aragon/buidler-aragon/-/buidler-aragon-0.2.3.tgz#cd8a6e63e284a313fe270d637d8137ae3b430c07"
@@ -36,6 +41,11 @@
     ethereumjs-abi "^0.6.4"
     web3-eth-abi "^1.2.1"
     web3-utils "^1.2.1"
+
+"@aragon/minime@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/minime/-/minime-1.0.0.tgz#994284b38e2ca36b5ae923f090928948041c928f"
+  integrity sha512-FU6xQXkkRfaxo0n6HEnlsizSA12Te2bghozqW9XLdDbzpC84yDeqUOQAxmrHo5yQPIezRfz7IrNzpLVL6ZBORA==
 
 "@nomiclabs/buidler-etherscan@^1.0.2":
   version "1.2.0"


### PR DESCRIPTION
This PR adds a creation script in buidler-hooks for installing a token manager instance, which is needed to properly test the insurance app. All of this is done in the postDao function.

This also adds the ~very funny hack~ ability to import external contracts by adding the TestImport.sol file.